### PR TITLE
Add error handlers to question controller

### DIFF
--- a/api/controllers/question.js
+++ b/api/controllers/question.js
@@ -23,23 +23,62 @@ questionRouter.post('/', tokenExtractor, userExtractor, async (request, response
     return response.status(401).end()
   }
 
-  const savedQuestion = await question.save()
-  return response.status(201).json(savedQuestion)
-
+  try {
+    const savedQuestion = await question.save()
+    return response.status(201).json(savedQuestion)
+  } catch (error) {
+    return response.json({
+      msg: `Something went wrong ${error}`
+    })
+  }
 })
 
 questionRouter.put('/:id', tokenExtractor, userExtractor, async (request, response) => {
-  const updatedQuestion = await Question.findByIdAndUpdate(request.params.id, request.body, { new: true })
-  return response.json(updatedQuestion)
-})
 
+  try {
+
+    const updatedQuestion = await Question.findByIdAndUpdate(request.params.id, request.body, { new: true })
+
+    if (!updatedQuestion) {
+      return response.status(400).json({
+        msg: "The id is not valid or doesn't exist on DB"
+      })
+    }
+
+    return response.json(updatedQuestion)
+
+  } catch (error) {
+    return response.json({
+      msg: `Something went wrong ${error}`
+    })
+  }
+
+})
 
 questionRouter.get('/:id', tokenExtractor, userExtractor, async (request, response) => {
   const questionId = request.params.id
 
-  const questionById = await Question.findById(questionId)
+  if (!questionId) {
+    return response.status(400).json({
+      msg: 'The id is missing'
+    })
+  }
 
-  return response.status(200).json(questionById)
+  try {
+    const questionById = await Question.findById(questionId)
+    if (!questionById) {
+      return response.status(400).json({
+        msg: "The id is not valid or doesn't exist on DB"
+      })
+    }
+    return response.status(200).json(questionById)
+
+  }
+  catch (error) {
+    return response.status(400).json({
+      msg: `Something went wrong ${error}`
+    })
+  }
 })
 
 questionRouter.get('/', tokenExtractor, userExtractor, async (request, response) => {
@@ -63,8 +102,19 @@ questionRouter.get('/', tokenExtractor, userExtractor, async (request, response)
 })
 
 questionRouter.delete('/:id', tokenExtractor, userExtractor, async (request, response) => {
-  await Question.findByIdAndRemove(request.params.id)
-  return response.status(204).end()
+
+  try {
+    const questionDeleted = await Question.findByIdAndRemove(request.params.id)
+
+    return response.status(204).json(questionDeleted)
+
+  }
+  catch (error) {
+    return response.status(400).json({
+      msg: `Something went wrong: ${error}`
+    })
+  }
+
 })
 
 module.exports = questionRouter


### PR DESCRIPTION
Description:
The errors are not handled in any way on the back end, a single bad request can kill the server.
If I send a request to create a new question from a different place other than the frontend (postman i.e.) with the wrong body/id the whole server crashes

Same thing happens when you try to update or get a question by ID.

Actions taken:
- Add validations and `try` - `catch` to every request on the question controller to handle errors in a efficient way

Now if you try to send the wrong request the server will return information on why the request is not correct and everything will keep running.
